### PR TITLE
Publish to PyPi

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,35 @@
+# Inspired by https://github.com/JonasKs/django-guid/blob/master/.github/workflows/publish_to_pypi.yml
+name: Publish ise to PyPI and TestPyPI 📦
+
+on: push
+
+jobs:
+  build-and-publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-publish-pypi.txt
+    - name: Build
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution of django-guid to Test PyPI 📦
+      # If it's a push, and the push includes a tag with `-rc` in it, release to TestPyPi
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.ref, '-rc')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution of django-guid to PyPI 📦
+      # If it's a push, and the push does _not_ contain `-rc` in it, release to production PyPi
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && !contains(github.ref, '-rc')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -20,14 +20,14 @@ jobs:
     - name: Build
       run: |
         python setup.py sdist bdist_wheel
-    - name: Publish distribution of django-guid to Test PyPI 📦
+    - name: Publish distribution of ise to Test PyPI 📦
       # If it's a push, and the push includes a tag with `-rc` in it, release to TestPyPi
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.ref, '-rc')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution of django-guid to PyPI 📦
+    - name: Publish distribution of ise to PyPI 📦
       # If it's a push, and the push does _not_ contain `-rc` in it, release to production PyPi
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && !contains(github.ref, '-rc')
       uses: pypa/gh-action-pypi-publish@master

--- a/requirements-publish-pypi.txt
+++ b/requirements-publish-pypi.txt
@@ -1,0 +1,3 @@
+setuptools==44.0.0
+twine==3.1.1
+wheel==0.33.6

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,20 @@
 from setuptools import find_packages, setup
 
+with open('README.md') as readme_file:
+    readme = readme_file.read()
+
 
 setup(
     name='ISE',
     version='1.1.0',
     py_modules=['ise'],
-    url='',
+    url='https://github.com/falkowich/ise',
+    download_url='https://pypi.python.org/pypi/ise',
     license='LICENSE.md',
     maintainer='Jonathan Karras',
     maintainer_email='jonathankarras@weber.edu',
-    description='',
-    long_description='README.md',
+    description='API wrapper for ISE',
+    long_description=readme,
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Hello,
I've seen issue #50, and decided to implement GitHub `workflows` to solve your issue. We consider using your package, but won't do so unless it's on PyPi due to our build process. I **strongly** recommend reading through [the packaging documentation](https://packaging.python.org/tutorials/packaging-projects/), as it will go more into detail.

In order to make this work, you have to do the following:
- Register a user at https://test.pypi.org/
- Register a user at https://pypi.org/
- Create a token [here](https://test.pypi.org/manage/account/#api-tokens ) (Also do this for the non-test PyPi)
- Create API token secrets in GitHub with these names:
    - `pypi_password`
    - `test_pypi_password`

You can then use your `setup.py` version to bump versions. In order to release to the `Test-PyPI` you create a tag that includes `-rc`, such as `1.1.1.0-rc`. When you want to publish to the real PyPi, do not include the `-rc`, like this: `1.1.1`.

You can do it through Github GUI [here](https://github.com/falkowich/ise/releases/new), like this:
![image](https://user-images.githubusercontent.com/5310116/75152905-6a201b80-570a-11ea-9703-dacfd661500c.png)
