### PR TITLE
Endpoint Groups improvements

### DIFF
--- a/ise.py
+++ b/ise.py
@@ -60,6 +60,18 @@ class ERS(object):
             return False
 
     @staticmethod
+    def _oid_test(id):
+        """
+        Test for a valid OID
+        :param id: OID in the form of abcd1234-ef56-7890-abcd1234ef56
+        :return: True/False
+        """
+        if re.match(r'^([a-f0-9]{8}-([a-f0-9]{4}-){3}[a-z0-9]{12})$', id):
+            return True
+        else:
+            return False
+
+    @staticmethod
     def _pass_ersresponse(result, resp):
         result['response'] = resp.json()['ERSResponse']['messages'][0]['title']
         result['error'] = resp.status_code
@@ -98,6 +110,7 @@ class ERS(object):
             result['success'] = True
             result['response'] = [(i['name'], i['id'], i['description'])
                                   for i in resp.json()['SearchResult']['resources']]
+            result['total'] = resp.json()['SearchResult']['total']
             return result
         else:
             return ERS._pass_ersresponse(result, resp)
@@ -179,9 +192,20 @@ class ERS(object):
             'error': '',
         }
 
-        resp = self.ise.get(
-            '{0}/config/endpointgroup?filter=name.EQ.{1}'.format(self.url_base, group))
-        found_group = resp.json()
+        # If it's a valid OID, perform a more direct GET-call
+        if self._oid_test(group):
+            resp = self.ise.get('{0}/config/endpointgroup/{1}'.format(self.url_base, group))
+            result = self.get_object(
+                '{0}/config/endpointgroup'.format(self.url_base),
+                resp.json()['EndPointGroup']['id'],
+                'EndPointGroup'
+            )
+            return result
+        # If not valid OID, perform regular search
+        else:
+            resp = self.ise.get(
+                '{0}/config/endpointgroup?filter=name.EQ.{1}'.format(self.url_base, group))
+            found_group = resp.json()
 
         if found_group['SearchResult']['total'] == 1:
             result = self.get_object('{0}/config/endpointgroup'.format(self.url_base), found_group['SearchResult']['resources'][0]['id'], "EndPointGroup")  # noqa E501

--- a/ise.py
+++ b/ise.py
@@ -194,10 +194,9 @@ class ERS(object):
 
         # If it's a valid OID, perform a more direct GET-call
         if self._oid_test(group):
-            resp = self.ise.get('{0}/config/endpointgroup/{1}'.format(self.url_base, group))
             result = self.get_object(
                 '{0}/config/endpointgroup'.format(self.url_base),
-                resp.json()['EndPointGroup']['id'],
+                group,
                 'EndPointGroup'
             )
             return result


### PR DESCRIPTION
Hi,

I've been using this package for some simple ISE interaction at work and found some room for improvements specifically in the `get_endpoint_group` method.

This PR will:
- Add an OID-validator.
- Check if the group-variable is an ID or a name, and if it's a valid OID it will perform a more direct GET on the requested object. 
- Add additional result-field `total` in `_get_groups`, helpful in cases where the programmer does not know how many groups there are in their local ISE environment.

This change allows for a search on either a group-name or group OID, the returned result-dict is equal in both cases.