### PR TITLE
Obtain version on class init, allow compatibility with 2.x and 3.x APIs.

### DIFF
--- a/ise.py
+++ b/ise.py
@@ -20,7 +20,7 @@ class InvalidMacAddress(Exception):
 
 
 class ERS(object):
-    def __init__(self, ise_node, ers_user, ers_pass, verify=False, disable_warnings=False, use_csrf=False, timeout=4,
+    def __init__(self, ise_node, ers_user, ers_pass, verify=False, disable_warnings=False, use_csrf=False, timeout=2,
                  protocol='https'):
         """
         Class to interact with Cisco ISE via the ERS API.

--- a/ise.py
+++ b/ise.py
@@ -4,6 +4,7 @@ import os
 import re
 from furl import furl
 from datetime import datetime, timedelta
+from bs4 import BeautifulSoup
 
 import requests
 
@@ -19,7 +20,7 @@ class InvalidMacAddress(Exception):
 
 
 class ERS(object):
-    def __init__(self, ise_node, ers_user, ers_pass, verify=False, disable_warnings=False, use_csrf=False, timeout=2,
+    def __init__(self, ise_node, ers_user, ers_pass, verify=False, disable_warnings=False, use_csrf=False, timeout=4,
                  protocol='https'):
         """
         Class to interact with Cisco ISE via the ERS API.
@@ -47,9 +48,10 @@ class ERS(object):
         self.csrf_expires = None
         self.timeout = timeout
         self.ise.headers.update({'Connection': 'keep_alive'})
-
+    
         if self.disable_warnings:
             requests.packages.urllib3.disable_warnings()
+        self.version = self.get_version()
 
     @staticmethod
     def _mac_test(mac):
@@ -139,6 +141,22 @@ class ERS(object):
             req = self.ise.request(method, url, data=data, timeout=self.timeout)
 
         return req
+
+    def get_version(self):
+        try:
+            # Build MnT API URL
+            url =  "https://" + self.ise_node + "/admin/API/mnt/Version"
+            # Access MnT API
+            req = self.ise.request('get', url, data=None, timeout=self.timeout)
+            # Extract version of first node
+            soup = BeautifulSoup(req.content,'xml')
+            full_version = soup.find_all('version')[0].get_text()
+            # Get simple version ie: 2.7
+            short_version = float(full_version[0:3])
+            # print("ISE Initializing - Version Check " + full_version)
+            return short_version
+        except:
+            return ""
 
     def _get_groups(self, url, filter: str = None, size: int = 20, page: int = 1):
         """

--- a/requirements-publish-pypi.txt
+++ b/requirements-publish-pypi.txt
@@ -1,3 +1,5 @@
 setuptools==46.1.3
 twine==3.1.1
 wheel==0.34.2
+beautifulsoup4==4.9.3
+lxml==4.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@
 
 furl
 requests
+beautifulsoup4
+lxml


### PR DESCRIPTION
Was looking for a few ISE calls to support a NetBox plugin for ISE and this worked well for adding and deleting endpoints, and I started thinking about 3.x support.

There is a workaround suggested on the Issue thread, but it requires modifying the library and maintaining a fork of the code vs the Pypi library, and, it doesn't have backward compatibility which I would like. 

The idea is the class will initialize with a slightly longer timeout (changing from 2 -> 4 seconds) to obtain the version from the ISE API. If it succeeds, it stores a short version string on the class, if not, it's just empty ''.
If this direction is approved, this could determine how to obtain backwards compatibility and call functions differently and automatically on 2.x vs 3.x.
Tag:  Issue #148 ISE 3.x support.
