### PR TITLE
Enhancement to Device Group and Device Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.code-workspace
+scratch*
 .idea/*
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -340,6 +340,16 @@ ise.add_device_group(name="Device Type#All Device Types#Python Device Type", des
  'error': ''}
 ```
 
+#### Update a device group 
+
+```python
+ise.update_device_group(device_group_oid=group_id, name="Device Type#All Device Types#Updated Device Type", description="Update Description")
+
+{'success': True,
+ 'response': 'e7db3e00-a36d-11eb-ac01-36750594a888 Updated Successfully',
+ 'error': ''}
+```
+
 #### Remove a device group 
 
 ```python

--- a/README.md
+++ b/README.md
@@ -266,6 +266,26 @@ ise.get_device_groups()['response']
 
 ```
 
+#### Add a new device group 
+
+```python
+ise.add_device_group(name="Device Type#All Device Types#Python Device Type", description="From Python")
+
+{'success': True,
+ 'response': 'Device Type#All Device Types#Python Device Type Added Successfully',
+ 'error': ''}
+```
+
+#### Remove a device group 
+
+```python
+ise.delete_device_group(name="Device Type#All Device Types#Python Device Type")
+
+{'success': True,
+ 'response': 'Device Type#All Device Types#Python Device Type Deleted Successfully',
+ 'error': ''}
+```
+
 #### Add a device
 
 ```python
@@ -278,7 +298,6 @@ ise.add_device(name='testdevice03',
                dev_type='Device Type#All Device Types#Switch')
 
 {'error': '', 'response': 'testdevice03 Added Successfully', 'success': True}
-
 ```
 
 #### Delete a device

--- a/README.md
+++ b/README.md
@@ -266,6 +266,70 @@ ise.get_device_groups()['response']
 
 ```
 
+#### Get device group(s) details
+
+```python
+# Provide a device_group_id 
+ise.get_device_group(device_group_id="4b26b5b0-71a6-11eb-b5e0-52cf9299494c")
+
+{'success': True,
+ 'response': {'id': '4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+  'name': 'Device Type#All Device Types#NXOS',
+  'description': '',
+  'link': {'rel': 'self',
+   'href': 'https://tst01-z0-vm-ise-01:9060/ers/config/networkdevicegroup/4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+   'type': 'application/json'},
+  'othername': 'Device Type'},
+ 'error': ''}
+
+
+# Provide a partial group name to look for 
+ise.get_device_group(name="NXOS")
+
+{'success': True,
+ 'response': {'id': '4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+  'name': 'Device Type#All Device Types#NXOS',
+  'description': '',
+  'link': {'rel': 'self',
+   'href': 'https://tst01-z0-vm-ise-01:9060/ers/config/networkdevicegroup/4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+   'type': 'application/json'},
+  'othername': 'Device Type'},
+ 'error': ''}
+
+# If more than one group found with for a name a list is returned
+ise.get_device_group(name="Device Types")
+
+[
+  {'success': True,
+  'response': {'id': '70c79c30-8bff-11e6-996c-525400b48521',
+   'name': 'Device Type#All Device Types',
+   'description': 'All Device Types',
+   'link': {'rel': 'self',
+    'href': 'https://tst01-z0-vm-ise-01:9060/ers/config/networkdevicegroup/70c79c30-8bff-11e6-996c-525400b48521',
+    'type': 'application/json'},
+   'othername': 'Device Type'},
+  'error': ''},
+ {'success': True,
+  'response': {'id': 'ee45c0a0-7fbc-11eb-ac01-36750594a888',
+   'name': 'Device Type#All Device Types#IOS-XE',
+   'description': '',
+   'link': {'rel': 'self',
+    'href': 'https://tst01-z0-vm-ise-01:9060/ers/config/networkdevicegroup/ee45c0a0-7fbc-11eb-ac01-36750594a888',
+    'type': 'application/json'},
+   'othername': 'Device Type'},
+  'error': ''},
+ {'success': True,
+  'response': {'id': '4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+   'name': 'Device Type#All Device Types#NXOS',
+   'description': '',
+   'link': {'rel': 'self',
+    'href': 'https://tst01-z0-vm-ise-01:9060/ers/config/networkdevicegroup/4b26b5b0-71a6-11eb-b5e0-52cf9299494c',
+    'type': 'application/json'},
+   'othername': 'Device Type'},
+  'error': ''},
+]
+```
+
 #### Add a new device group 
 
 ```python

--- a/README.md
+++ b/README.md
@@ -374,6 +374,19 @@ ise.add_device(name='testdevice03',
 {'error': '', 'response': 'testdevice03 Added Successfully', 'success': True}
 ```
 
+#### Update a device 
+
+```python
+ise.update_device("PYTHON-DEVICE", tacacs_shared_secret="NEWTACACS")
+
+{'success': True,
+ 'response': {'updatedField': [{'field': 'TacacsSettings.ConnectModeOptions',
+    'oldValue': '',
+    'newValue': 'ON_LEGACY'},
+   {'field': 'TacacsSettings.SharedSecret', 'newValue': 'NEWTACACS'}]},
+ 'error': ''}
+```
+
 #### Delete a device
 
 ```python

--- a/ise.py
+++ b/ise.py
@@ -1244,6 +1244,42 @@ class ERS(object):
         return self.get_object('{0}/config/networkdevicegroup/'.format(self.url_base), device_group_oid, 'NetworkDeviceGroup')  # noqa E501
 
     # TODO: Add an add_device_group method 
+    def add_device_group(self, name, description=""): 
+        """
+        Add a Network Device Group 
+
+        :param name: Full name of the group to add. (Example: "Device Type#All Device Types#ASA Firewall)
+        :param description: Optional description for group
+
+        :return: Result dictionary
+        """
+        result = {
+            'success': False,
+            'response': '',
+            'error': '',
+        }
+
+        self.ise.headers.update(
+            {'ACCEPT': 'application/json', 'Content-Type': 'application/json'})
+
+        data = {
+            "NetworkDeviceGroup": {
+                "name": name,
+                "description": description, 
+                "othername": name.split("#")[0]
+            }
+        }
+
+        resp = self._request('{0}/config/networkdevicegroup'.format(self.url_base), method='post',
+                             data=json.dumps(data))
+
+        if resp.status_code == 201:
+            result['success'] = True
+            result['response'] = '{0} Added Successfully'.format(name)
+            return result
+        else:
+            return ERS._pass_ersresponse(result, resp)
+
     # TODO: Add a delete_device_group method 
 
     def get_devices(self, filter=None, size=20, page=1):

--- a/ise.py
+++ b/ise.py
@@ -1284,8 +1284,6 @@ class ERS(object):
         else:
             return ERS._pass_ersresponse(result, resp)
 
-    # TODO: Make radius and snmp optional 
-    # TODO: Make groups a list
     def add_device(self,
                    name,
                    ip_address,
@@ -1300,20 +1298,36 @@ class ERS(object):
                    snmp_v='TWO_C',
                    dev_profile='Cisco',
                    tacacs_shared_secret=None,
-                   tacas_connect_mode_options='ON_LEGACY'
+                   tacas_connect_mode_options='ON_LEGACY', 
+                   coa_port=1700, 
+                   snmp_version = "TWO_C", 
+                   snmp_polling_interval = 3600, 
+                   snmp_link_trap_query = "true", 
+                   snmp_mac_trap_query = "true", 
+                   snmp_originating_policy_services_node="Auto",
                    ):
         """
         Add a device.
 
         :param name: name of device
         :param ip_address: IP address of device
-        :param radius_key: Radius shared secret
-        :param snmp_ro: SNMP read only community string
-        :param dev_group: Device group name
-        :param dev_location: Device location
-        :param dev_type: Device type
-        :param description: Device description
-        :param dev_profile: Device profile
+        :param description: Device description (default "")
+        :param dev_group: Custom device group name, string or list (default None)
+        :param dev_location: Device location (default "Location#All Locations")
+        :param dev_type: Device type (default "Device Type#All Device Types")
+        :param dev_ipsec: IPSEC Status for device (default "IPSEC#Is IPSEC Device#No")
+        :param radius_key: Radius shared secret (default None)
+        :param snmp_ro: SNMP read only community string (default None)
+        :param dev_profile: Device profile (default "Cisco")
+        :param tacacs_shared_secret: Tacacs shared secret  (default None)
+        :param tacas_connect_mode_options: Tacacs connect mode  (default 'ON_LEGACY',)
+        :param coa_port: Change of Auth port  (default 1700)
+        :param snmp_version: SNMP Version  (default "TWO_C")
+        :param snmp_polling_interval: SNMP Polling Interval  (default 3600)
+        :param snmp_link_trap_query: SNMP Link Trap  (default "true")
+        :param snmp_mac_trap_query: SNMP MAC Trap  (default "true")
+        :param snmp_originating_policy_services_node: SNMP Policy Node  (default "Auto")
+
         :return: Result dictionary
         """
         result = {
@@ -1328,14 +1342,14 @@ class ERS(object):
         data = {'NetworkDevice': {'name': name,
                                   'description': description,
                                   'profileName': dev_profile,
-                                  'coaPort': 1700,
+                                  'coaPort': coa_port,
                                   'NetworkDeviceIPList': [{
                                       'ipaddress': ip_address,
                                       'mask': mask,
                                   }],
                                   'NetworkDeviceGroupList': [
                                       dev_type, dev_location,
-                                      'IPSEC#Is IPSEC Device#No'
+                                      dev_ipsec
                                     ]
                                   }
                 }
@@ -1355,12 +1369,12 @@ class ERS(object):
         
         if snmp_ro is not None: 
             data["NetworkDevice"]["snmpsettings"] = {
-                                      'version': 'TWO_C',
+                                      'version': snmp_version,
                                       'roCommunity': snmp_ro,
-                                      'pollingInterval': 3600,
-                                      'linkTrapQuery': 'true',
-                                      'macTrapQuery': 'true',
-                                      'originatingPolicyServicesNode': 'Auto'
+                                      'pollingInterval': snmp_polling_interval,
+                                      'linkTrapQuery': snmp_link_trap_query,
+                                      'macTrapQuery': snmp_mac_trap_query,
+                                      'originatingPolicyServicesNode': snmp_originating_policy_services_node
                                   }
 
         if dev_group is not None: 

--- a/ise.py
+++ b/ise.py
@@ -1243,6 +1243,9 @@ class ERS(object):
 
         return self.get_object('{0}/config/networkdevicegroup/'.format(self.url_base), device_group_oid, 'NetworkDeviceGroup')  # noqa E501
 
+    # TODO: Add an add_device_group method 
+    # TODO: Add a delete_device_group method 
+
     def get_devices(self, filter=None, size=20, page=1):
         """
         Get a list of devices.
@@ -1281,6 +1284,8 @@ class ERS(object):
         else:
             return ERS._pass_ersresponse(result, resp)
 
+    # TODO: Make radius and snmp optional 
+    # TODO: Make groups a list
     def add_device(self,
                    name,
                    ip_address,

--- a/ise.py
+++ b/ise.py
@@ -1281,6 +1281,8 @@ class ERS(object):
         else:
             return ERS._pass_ersresponse(result, resp)
 
+    # TODO: Add update_device_group function 
+
     def delete_device_group(self, name): 
         """
         Delete a Network Device Group

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ISE',
-    version='0.1.2',
+    version='0.1.2.e0',
     py_modules=['ise'],
     url='https://github.com/falkowich/ise',
     download_url='https://pypi.python.org/pypi/ise',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ISE',
-    version='0.1.2.e0',
+    version='0.1.2.e1',
     py_modules=['ise'],
     url='https://github.com/falkowich/ise',
     download_url='https://pypi.python.org/pypi/ise',


### PR DESCRIPTION
First, thanks for putting work together on this library.  As I was diving into my first Cisco ISE programmability project I was happy to find a library that had much of what I needed already worked out.  There were a handful of features/functions that were missing for my project.  I went ahead and added them to the library, trying to stick with the general style and functionality of the library.  

Here's what I think is a summary of the features/changes included here: 

Fleshing out the CRUD for Device Groups 

2. A function to `add_device_group` that adds a new device group 
3. A function to `update_device_group` that, you guessed it, updates a device group. 
4. A function to `delete_device_group`.  I bet you can guess what this does

And putting the "U" into CRUD for devices

1. A new function for `update_device` to allow updating a device.  This one was complicated to support the variety of update options for a device.  

In addition to the new functions, I enhanced a couple of existing functions 

1. Updates to `get_device_group` that looks up a device group from ISE given a group ID, name, or partial name. 
1. Updates to `add_device` to make all the attributes configurable as function parameters.  I also provided an alternative option of providing a device payload as a single dictionary rather than individual attributes.  

Let me know any questions or requests for tweaks to the PR.  I'd love to contribute back into the library for others to take advantage of.  